### PR TITLE
Fix missing parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,4 +23,5 @@ runs:
   args:
     - ${{ inputs.manifest }}
     - ${{ inputs.catalog }}
+    - ${{ inputs.account }}
     - ${{ inputs.s3-path }}


### PR DESCRIPTION
- Missed `account` param definition in docker file running param